### PR TITLE
fix(1007): Add method signature to get coverage links

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,25 @@ This is an interface for uploading code coverage results from a Screwdriver buil
 ##### Expected Outcome
 The `getAccessToken` function should resolve a Promise with an access token that build can use to talk to the code coverage server.
 
+### getLinks
+##### Required Parameters
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| jobId        | String | Coverage job ID |
+
+##### Expected Outcome
+The `getLinks` function should resolve a Promise with an object with links to the coverage badge and project.
+
 ### getUploadCoverageCmd
 ##### Expected Outcome
 The `getUploadCoverageCmd` function should resolve a Promise with a string of shell commands to upload code coverage results.
 
 ## Extending
 To extend the base class, the functions to override are:
+1. `_getAccessToken`
+1. `_getLinks`
 1. `_getUploadCoverageCmd`
-2. `_getAccessToken`
+
 
 ## Testing
 

--- a/index.js
+++ b/index.js
@@ -4,11 +4,39 @@
 class CoverageBase {
     /** Constructor for Coverage plugin
      * @method Constructor
-     * @param {Object}  config  Configuration
-     * @return {CoverageBase}
+     * @param   {Object}    config  Configuration
+     * @return  {CoverageBase}
      */
     constructor(config) {
         this.config = config;
+    }
+
+    /**
+     * Return an access token that build can use to talk to coverage server
+     * @method getAccessToken
+     * @param   {Object}  buildCredentials    Infomation stored in a build JWT
+     * @return  {Promise}                     An access token that build can use to talk to coverage server
+     */
+    getAccessToken(buildCredentials) {
+        return this._getAccessToken(buildCredentials);
+    }
+
+    _getAccessToken() {
+        return Promise.reject('Not implemented');
+    }
+
+    /**
+     * Return coverage links
+     * @method getLinks
+     * @param   {Object}  jobId    Coverage job ID
+     * @return  {Promise}          An object with links to the coverage
+     */
+    getLinks(jobId) {
+        return this._getLinks(jobId);
+    }
+
+    _getLinks() {
+        return Promise.reject('Not implemented');
     }
 
     /**
@@ -21,20 +49,6 @@ class CoverageBase {
     }
 
     _getUploadCoverageCmd() {
-        return Promise.reject('Not implemented');
-    }
-
-    /**
-     * Return an access token that build can use to talk to coverage server
-     * @method getAccessToken
-     * @param {Object}  buildCredentials    Infomation stored in a build JWT
-     * @return {Promise}                    An access token that build can use to talk to coverage server
-     */
-    getAccessToken(buildCredentials) {
-        return this._getAccessToken(buildCredentials);
-    }
-
-    _getAccessToken() {
         return Promise.reject('Not implemented');
     }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -20,8 +20,8 @@ describe('index test', () => {
         assert.instanceOf(instance, CoverageBase);
     });
 
-    it('should catch an error for getUploadCoverageCmd', () => {
-        instance.getUploadCoverageCmd({})
+    it('should catch an error for getAccessToken', () => {
+        instance.getAccessToken({})
             .then(() => {
                 throw new Error('Should not get here');
             }, (err) => {
@@ -30,8 +30,18 @@ describe('index test', () => {
             });
     });
 
-    it('should catch an error for getAccessToken', () => {
-        instance.getAccessToken({})
+    it('should catch an error for getLinks', () => {
+        instance.getLinks({})
+            .then(() => {
+                throw new Error('Should not get here');
+            }, (err) => {
+                assert.isOk(err, 'Error should be returned');
+                assert.equal(err.message, 'Not implemented');
+            });
+    });
+
+    it('should catch an error for getUploadCoverageCmd', () => {
+        instance.getUploadCoverageCmd({})
             .then(() => {
                 throw new Error('Should not get here');
             }, (err) => {


### PR DESCRIPTION
## Context
Users would like to get a link to their badge and how to get to the project.

## Objective
This PR adds a method signature to return coverage links.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1007