### PR TITLE
fix(1007): Take in object with IDs for getLinks (1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is an interface for uploading code coverage results from a Screwdriver buil
 ### getAccessToken
 ##### Required Parameters
 | Parameter        | Type  |  Description |
-| :-------------   | :---- | :-------------|
+| :--------------- | :---- | :----------- |
 | buildCredentials        | Object | Information stored in the build JWT token |
 
 ##### Expected Outcome
@@ -23,9 +23,11 @@ The `getAccessToken` function should resolve a Promise with an access token that
 
 ### getLinks
 ##### Required Parameters
-| Parameter        | Type  |  Description |
-| :-------------   | :---- | :-------------|
-| jobId        | String | Coverage job ID |
+| Parameter        | Type   |  Description |
+| :--------------- | :----- | :----------- |
+| config           | Object |              |
+| config.buildId   | String | The unique ID for a build |
+| config.jobId     | String | The unique ID for a job |
 
 ##### Expected Outcome
 The `getLinks` function should resolve a Promise with an object with links to the coverage badge and project.

--- a/index.js
+++ b/index.js
@@ -28,11 +28,13 @@ class CoverageBase {
     /**
      * Return coverage links
      * @method getLinks
-     * @param   {Object}  jobId    Coverage job ID
-     * @return  {Promise}          An object with links to the coverage
+     * @param   {Object}  config
+     * @param   {String}  config.buildId    Screwdriver build ID
+     * @param   {String}  config.jobId      Screwdriver job ID
+     * @return  {Promise}                   An object with links to the coverage
      */
-    getLinks(jobId) {
-        return this._getLinks(jobId);
+    getLinks(config) {
+        return this._getLinks(config);
     }
 
     _getLinks() {


### PR DESCRIPTION
Some coverage plugins might need the buildId, the sonar coverage plugin requires the jobId. We'll have the UI pass in both since it should have access to both and the coverage plugin will decide what to do with it.

Related to https://github.com/screwdriver-cd/screwdriver/issues/1007