### PR TITLE
fix(1007): Change getLinks to getInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,21 +16,23 @@ This is an interface for uploading code coverage results from a Screwdriver buil
 ##### Required Parameters
 | Parameter        | Type  |  Description |
 | :--------------- | :---- | :----------- |
-| buildCredentials        | Object | Information stored in the build JWT token |
+| buildCredentials | Object | Information stored in the build JWT token |
 
 ##### Expected Outcome
 The `getAccessToken` function should resolve a Promise with an access token that build can use to talk to the code coverage server.
 
-### getLinks
+### getInfo
 ##### Required Parameters
 | Parameter        | Type   |  Description |
 | :--------------- | :----- | :----------- |
 | config           | Object |              |
 | config.buildId   | String | The unique ID for a build |
 | config.jobId     | String | The unique ID for a job |
+| config.startTime | String | The job start time |
+| config.endTime   | String | The job end time |
 
 ##### Expected Outcome
-The `getLinks` function should resolve a Promise with an object with links to the coverage badge and project.
+The `getInfo` function should resolve a Promise with an object with metadata about the project coverage.
 
 ### getUploadCoverageCmd
 ##### Expected Outcome
@@ -39,7 +41,7 @@ The `getUploadCoverageCmd` function should resolve a Promise with a string of sh
 ## Extending
 To extend the base class, the functions to override are:
 1. `_getAccessToken`
-1. `_getLinks`
+1. `_getInfo`
 1. `_getUploadCoverageCmd`
 
 

--- a/index.js
+++ b/index.js
@@ -26,18 +26,20 @@ class CoverageBase {
     }
 
     /**
-     * Return coverage links
-     * @method getLinks
+     * Return coverage metadata, such as links to the project and coverage percentage
+     * @method getInfo
      * @param   {Object}  config
      * @param   {String}  config.buildId    Screwdriver build ID
      * @param   {String}  config.jobId      Screwdriver job ID
-     * @return  {Promise}                   An object with links to the coverage
+     * @param   {String}  config.startTime  Time the job started
+     * @param   {String}  config.endTime    Time the job ended
+     * @return  {Promise}                   An object with coverage metadata
      */
-    getLinks(config) {
-        return this._getLinks(config);
+    getInfo(config) {
+        return this._getInfo(config);
     }
 
-    _getLinks() {
+    _getInfo() {
         return Promise.reject('Not implemented');
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -30,8 +30,8 @@ describe('index test', () => {
             });
     });
 
-    it('should catch an error for getLinks', () => {
-        instance.getLinks({})
+    it('should catch an error for getInfo', () => {
+        instance.getInfo({})
             .then(() => {
                 throw new Error('Should not get here');
             }, (err) => {


### PR DESCRIPTION
Converting the `getLinks` function to something more generic such as `getInfo`. This method should just return metadata about the job's coverage, including things like the project link, and coverage percentage.

Related to https://github.com/screwdriver-cd/screwdriver/issues/1007