### PR TITLE
fix(1754): [3] Add `isCoverageEnabled` function to verify coverage plugin enabled or not

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ class CoverageBase {
     getUploadCoverageCmd(config) {
         if (this.isCoverageEnabled(this.config, config.build) === 'false') {
             const skipMessage = 'Coverage feature is skipped. ' +
-                'Set COVERAGE_PLUGIN_ENABLED environment true, if you want to get coverages.';
+                'Set SD_COVERAGE_PLUGIN_ENABLED environment true, if you want to get coverages.';
 
             return Promise.resolve(`echo ${skipMessage}`);
         }
@@ -68,15 +68,17 @@ class CoverageBase {
     /**
      * Verify to run coverage plugin or not
      * @method isCoverageEnabled
-     * @param   {Object}  clusterConfig  default coverage plugin setting at cluster level.
-     * @param   {Object}  buildConfig.environment.COVERAGE_PLUGIN_ENABLED coverage plugin setting in each builds.
-     * @return {Boolean}
+     * @param   {Object}  clusterConfig    Default coverage plugin setting at cluster level.
+     * @param   {Object}  buildConfig      Configurations in each builds.
+     * @param   {String}  buildConfig.environment.SD_COVERAGE_PLUGIN_ENABLED
+     *                    Coverage plugin enable setting by user. It should be 'true' or 'false'.
+     * @return {String}   'true' or 'false'
      */
     isCoverageEnabled(clusterConfig, buildConfig) {
         // if user has the configuration, use it
         if (buildConfig.environment &&
-            buildConfig.environment.COVERAGE_PLUGIN_ENABLED) {
-            return buildConfig.environment.COVERAGE_PLUGIN_ENABLED;
+            buildConfig.environment.SD_COVERAGE_PLUGIN_ENABLED) {
+            return buildConfig.environment.SD_COVERAGE_PLUGIN_ENABLED;
         }
 
         // if not, use cluster wide default

--- a/index.js
+++ b/index.js
@@ -68,17 +68,19 @@ class CoverageBase {
     /**
      * Verify to run coverage plugin or not
      * @method isCoverageEnabled
-     * @param   {Object}  clusterConfig  coverage plugin setting at cluster level.
+     * @param   {Object}  clusterConfig  default coverage plugin setting at cluster level.
      * @param   {Object}  buildConfig.environment.COVERAGE_PLUGIN_ENABLED coverage plugin setting in each builds.
      * @return {Boolean}
      */
     isCoverageEnabled(clusterConfig, buildConfig) {
-        if (buildConfig.environment === undefined ||
-            buildConfig.environment.COVERAGE_PLUGIN_ENABLED === undefined) {
-            return clusterConfig.enabled;
+        // if user has the configuration, use it
+        if (buildConfig.environment &&
+            buildConfig.environment.COVERAGE_PLUGIN_ENABLED) {
+            return buildConfig.environment.COVERAGE_PLUGIN_ENABLED;
         }
 
-        return buildConfig.environment.COVERAGE_PLUGIN_ENABLED;
+        // if not, use cluster wide default
+        return clusterConfig.default;
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -53,7 +53,8 @@ class CoverageBase {
     getUploadCoverageCmd(config) {
         if (this.isCoverageEnabled(this.config, config.build) === 'false') {
             const skipMessage = 'Coverage feature is skipped. ' +
-                'Set $SD_COVERAGE_PLUGIN_ENABLED true, if you want to get coverages.';
+                'Set SD_COVERAGE_PLUGIN_ENABLED environment value true, ' +
+                'if you want to get coverages.';
 
             return Promise.resolve(`echo ${skipMessage}`);
         }

--- a/index.js
+++ b/index.js
@@ -46,14 +46,39 @@ class CoverageBase {
     /**
      * Get shell command to upload coverage to server
      * @method getUploadCoverageCmd
-     * @return {Promise}     Shell commands to upload coverage
+     * @param   {Object}  config
+     * @param   {String}  config.build   build configuration
+     * @return {Promise}  Shell commands to upload coverage
      */
-    getUploadCoverageCmd() {
+    getUploadCoverageCmd(config) {
+        if (this.isCoverageEnabled(this.config, config.build) === 'false') {
+            const skipMessage = 'Coverage feature is skipped. ' +
+                'Set COVERAGE_PLUGIN_ENABLED environment true, if you want to get coverages.';
+
+            return Promise.resolve(`echo ${skipMessage}`);
+        }
+
         return this._getUploadCoverageCmd();
     }
 
     _getUploadCoverageCmd() {
         return Promise.reject('Not implemented');
+    }
+
+    /**
+     * Verify to run coverage plugin or not
+     * @method isCoverageEnabled
+     * @param   {Object}  clusterConfig  coverage plugin setting at cluster level.
+     * @param   {Object}  buildConfig.environment.COVERAGE_PLUGIN_ENABLED coverage plugin setting in each builds.
+     * @return {Boolean}
+     */
+    isCoverageEnabled(clusterConfig, buildConfig) {
+        if (buildConfig.environment === undefined ||
+            buildConfig.environment.COVERAGE_PLUGIN_ENABLED === undefined) {
+            return clusterConfig.enabled;
+        }
+
+        return buildConfig.environment.COVERAGE_PLUGIN_ENABLED;
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ class CoverageBase {
     getUploadCoverageCmd(config) {
         if (this.isCoverageEnabled(this.config, config.build) === 'false') {
             const skipMessage = 'Coverage feature is skipped. ' +
-                'Set SD_COVERAGE_PLUGIN_ENABLED environment value true, ' +
+                'Set SD_COVERAGE_PLUGIN_ENABLED environment variable true, ' +
                 'if you want to get coverages.';
 
             return Promise.resolve(`echo ${skipMessage}`);

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ class CoverageBase {
     getUploadCoverageCmd(config) {
         if (this.isCoverageEnabled(this.config, config.build) === 'false') {
             const skipMessage = 'Coverage feature is skipped. ' +
-                'Set SD_COVERAGE_PLUGIN_ENABLED environment true, if you want to get coverages.';
+                'Set $SD_COVERAGE_PLUGIN_ENABLED true, if you want to get coverages.';
 
             return Promise.resolve(`echo ${skipMessage}`);
         }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -41,12 +41,74 @@ describe('index test', () => {
     });
 
     it('should catch an error for getUploadCoverageCmd', () => {
-        instance.getUploadCoverageCmd({})
+        const config = {
+            build: {}
+        };
+
+        instance.getUploadCoverageCmd(config)
             .then(() => {
                 throw new Error('Should not get here');
             }, (err) => {
                 assert.isOk(err, 'Error should be returned');
                 assert.equal(err.message, 'Not implemented');
             });
+    });
+
+    describe('isCoverageEnabled test', () => {
+        it('should return true if enabled at cluster level, and buildConfig not defined.', () => {
+            const clusterConfig = {
+                enabled: 'true'
+            };
+            const buildConfig = {
+                environment: {}
+            };
+
+            assert.equal('true',
+                instance.isCoverageEnabled(clusterConfig, buildConfig)
+            );
+        });
+
+        it('should return false if enabled at cluster level, and disabled at buildConfig.', () => {
+            const clusterConfig = {
+                enabled: 'true'
+            };
+            const buildConfig = {
+                environment: {
+                    COVERAGE_PLUGIN_ENABLED: 'false'
+                }
+            };
+
+            assert.equal('false',
+                instance.isCoverageEnabled(clusterConfig, buildConfig)
+            );
+        });
+
+        it('should return false if disabled at cluster level, and buildConfig not defined.', () => {
+            const clusterConfig = {
+                enabled: 'false'
+            };
+            const buildConfig = {
+                environment: {}
+            };
+
+            assert.equal('false',
+                instance.isCoverageEnabled(clusterConfig, buildConfig)
+            );
+        });
+
+        it('should return true if disabled at cluster level, and enabled at build config.', () => {
+            const clusterConfig = {
+                enabled: 'false'
+            };
+            const buildConfig = {
+                environment: {
+                    COVERAGE_PLUGIN_ENABLED: 'true'
+                }
+            };
+
+            assert.equal('true',
+                instance.isCoverageEnabled(clusterConfig, buildConfig)
+            );
+        });
     });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -57,7 +57,7 @@ describe('index test', () => {
     describe('isCoverageEnabled test', () => {
         it('should return true if enabled at cluster level, and buildConfig not defined.', () => {
             const clusterConfig = {
-                enabled: 'true'
+                default: 'true'
             };
             const buildConfig = {
                 environment: {}
@@ -70,7 +70,7 @@ describe('index test', () => {
 
         it('should return false if enabled at cluster level, and disabled at buildConfig.', () => {
             const clusterConfig = {
-                enabled: 'true'
+                default: 'true'
             };
             const buildConfig = {
                 environment: {
@@ -85,7 +85,7 @@ describe('index test', () => {
 
         it('should return false if disabled at cluster level, and buildConfig not defined.', () => {
             const clusterConfig = {
-                enabled: 'false'
+                default: 'false'
             };
             const buildConfig = {
                 environment: {}
@@ -98,7 +98,7 @@ describe('index test', () => {
 
         it('should return true if disabled at cluster level, and enabled at build config.', () => {
             const clusterConfig = {
-                enabled: 'false'
+                default: 'false'
             };
             const buildConfig = {
                 environment: {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -74,7 +74,7 @@ describe('index test', () => {
             };
             const buildConfig = {
                 environment: {
-                    COVERAGE_PLUGIN_ENABLED: 'false'
+                    SD_COVERAGE_PLUGIN_ENABLED: 'false'
                 }
             };
 
@@ -102,7 +102,7 @@ describe('index test', () => {
             };
             const buildConfig = {
                 environment: {
-                    COVERAGE_PLUGIN_ENABLED: 'true'
+                    SD_COVERAGE_PLUGIN_ENABLED: 'true'
                 }
             };
 


### PR DESCRIPTION
## Context
When we use coverage-bookend, coverage scanning is executed all jobs, including jobs which is not necessary to scan.
It must be leads to longer build time, or surging database size.

## Objective
- Add `isCoverageEnabled()` function to verify coverage plugin enabled or not
- If build environment `SD_COVERAGE_PLUGIN_ENABLED` which is defined in screwdriver.yaml exists, follow its setting.
- If build environment `SD_COVERAGE_PLUGIN_ENABLED` dose not exist, follow cluster level settings which is defined [here](https://github.com/screwdriver-cd/screwdriver/blob/5e1fe087ddc620f15207b3e182236da19ac574fc/config/default.yaml#L235).

## References
Issue: https://github.com/screwdriver-cd/screwdriver/issues/1754
Other PRs
[1]: https://github.com/screwdriver-cd/screwdriver/pull/1758
[2]: https://github.com/screwdriver-cd/coverage-bookend/pull/4

## License
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.