### PR TITLE
feat(2152): Support scope annotation for Sonar. BREAKING CHANGE: new method signatures [1]

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The `getAccessToken` function should resolve a Promise with an access token that
 | Parameter        | Type   |  Description |
 | :--------------- | :----- | :----------- |
 | config           | Object |              |
-| config.annotations | Object | Job annotations | 
+| config.annotations | Object | Job annotations |
 | config.jobId     | String | The unique ID for a job |
 | config.jobName   | String | The Screwdriver job name |
 | config.pipelineId | String | The unique ID for a pipeline |

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The `getAccessToken` function should resolve a Promise with an access token that
 | config.prNum     | String | The pull request number |
 | config.startTime | String | The job start time |
 | config.endTime   | String | The job end time |
+| config.coverageProjectKey | String | Project key (can be directly passed in with just startTime and endTime) |
 
 ##### Expected Outcome
 The `getInfo` function should resolve a Promise with an object with metadata about the project coverage.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ This is an interface for uploading code coverage results from a Screwdriver buil
 ##### Required Parameters
 | Parameter        | Type  |  Description |
 | :--------------- | :---- | :----------- |
-| buildCredentials | Object | Information stored in the build JWT token |
+| config           | Object |             |
+| config.annotations | Object | Job annotations |
+| config.buildCredentials | Object | Information stored in the build JWT token |
 
 ##### Expected Outcome
 The `getAccessToken` function should resolve a Promise with an access token that build can use to talk to the code coverage server.
@@ -26,8 +28,12 @@ The `getAccessToken` function should resolve a Promise with an access token that
 | Parameter        | Type   |  Description |
 | :--------------- | :----- | :----------- |
 | config           | Object |              |
-| config.buildId   | String | The unique ID for a build |
+| config.annotations | Object | Job annotations | 
 | config.jobId     | String | The unique ID for a job |
+| config.jobName   | String | The Screwdriver job name |
+| config.pipelineId | String | The unique ID for a pipeline |
+| config.pipelineName | String | The Screwdriver pipeline name |
+| config.prNum     | String | The pull request number |
 | config.startTime | String | The job start time |
 | config.endTime   | String | The job end time |
 
@@ -35,6 +41,14 @@ The `getAccessToken` function should resolve a Promise with an access token that
 The `getInfo` function should resolve a Promise with an object with metadata about the project coverage.
 
 ### getUploadCoverageCmd
+##### Required Parameters
+| Parameter        | Type   |  Description |
+| :--------------- | :----- | :----------- |
+| config           | Object |              |
+| config.build     | String | The build    |
+| config.job       | String | The job      |
+| config.pipeline  | String | The pipeline |
+
 ##### Expected Outcome
 The `getUploadCoverageCmd` function should resolve a Promise with a string of shell commands to upload code coverage results.
 

--- a/index.js
+++ b/index.js
@@ -14,11 +14,13 @@ class CoverageBase {
     /**
      * Return an access token that build can use to talk to coverage server
      * @method getAccessToken
-     * @param   {Object}  buildCredentials    Infomation stored in a build JWT
-     * @return  {Promise}                     An access token that build can use to talk to coverage server
+     * @param   {Object}  config
+     * @param   {Object}  [config.annotations]      Job annotations
+     * @param   {Object}  config.buildCredentials   Information stored in a build JWT
+     * @return  {Promise}                           An access token that builds can use to talk to coverage server
      */
-    getAccessToken(buildCredentials) {
-        return this._getAccessToken(buildCredentials);
+    getAccessToken(config) {
+        return this._getAccessToken(config);
     }
 
     _getAccessToken() {
@@ -29,11 +31,13 @@ class CoverageBase {
      * Return coverage metadata, such as links to the project and coverage percentage
      * @method getInfo
      * @param   {Object}  config
-     * @param   {String}  config.buildId    Screwdriver build ID
-     * @param   {String}  config.jobId      Screwdriver job ID
-     * @param   {String}  config.startTime  Time the job started
-     * @param   {String}  config.endTime    Time the job ended
-     * @return  {Promise}                   An object with coverage metadata
+     * @param   {String}  [config.annotations]  Job annotations
+     * @param   {String}  config.jobId          Screwdriver job ID
+     * @param   {String}  [config.pipelineId]   Screwdriver pipeline ID (if enterprise is enabled)
+     * @param   {String}  [config.prNum]        Pull request number
+     * @param   {String}  config.startTime      Time the job started
+     * @param   {String}  config.endTime        Time the job ended
+     * @return  {Promise}                       An object with coverage metadata
      */
     getInfo(config) {
         return this._getInfo(config);
@@ -47,11 +51,16 @@ class CoverageBase {
      * Get shell command to upload coverage to server
      * @method getUploadCoverageCmd
      * @param   {Object}  config
-     * @param   {String}  config.build   build configuration
-     * @return {Promise}  Shell commands to upload coverage
+     * @param   {Object}  config.build          Build configuration
+     * @param   {Object}  config.job            Job configuration
+     * @param   {Object}  config.pipeline       Pipeline configuration
+     * @return  {Promise}  Shell commands to upload coverage
      */
     getUploadCoverageCmd(config) {
-        if (this.isCoverageEnabled(this.config, config.build) === 'false') {
+        const { build, job, pipeline } = config;
+        let annotations = {};
+
+        if (this.isCoverageEnabled(this.config, build) === 'false') {
             const skipMessage = 'Coverage feature is skipped. ' +
                 'Set SD_COVERAGE_PLUGIN_ENABLED environment variable true, ' +
                 'if you want to get coverages.';
@@ -59,7 +68,17 @@ class CoverageBase {
             return Promise.resolve(`echo ${skipMessage}`);
         }
 
-        return this._getUploadCoverageCmd();
+        if (job && job.permutations && job.permutations[0]) {
+            annotations = job.permutations[0].annotations;
+        }
+
+        return this._getUploadCoverageCmd({
+            annotations,
+            jobId: job.id,
+            pipelineId: pipeline.id,
+            jobName: job.name,
+            pipelineName: pipeline.name
+        });
     }
 
     _getUploadCoverageCmd() {

--- a/index.js
+++ b/index.js
@@ -31,13 +31,16 @@ class CoverageBase {
      * Return coverage metadata, such as links to the project and coverage percentage
      * @method getInfo
      * @param   {Object}  config
-     * @param   {String}  [config.annotations]  Job annotations
-     * @param   {String}  config.jobId          Screwdriver job ID
-     * @param   {String}  [config.pipelineId]   Screwdriver pipeline ID (if enterprise is enabled)
-     * @param   {String}  [config.prNum]        Pull request number
-     * @param   {String}  config.startTime      Time the job started
-     * @param   {String}  config.endTime        Time the job ended
-     * @return  {Promise}                       An object with coverage metadata
+     * @param   {String}  [config.annotations]          Job annotations
+     * @param   {String}  config.jobId                  Screwdriver job ID
+     * @param   {String}  [config.jobName]              Screwdriver job name
+     * @param   {String}  [config.pipelineId]           Screwdriver pipeline ID (if enterprise is enabled)
+     * @param   {String}  [config.pipelineName]         Screwdriver pipeline name
+     * @param   {String}  [config.prNum]                Pull request number
+     * @param   {String}  config.startTime              Time the job started
+     * @param   {String}  config.endTime                Time the job ended
+     * @param   {String}  [config.coverageProjectKey]   Project key
+     * @return  {Promise}                               An object with coverage metadata
      */
     getInfo(config) {
         return this._getInfo(config);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-coverage-base",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Base class defining the interface for coverage upload implementations",
   "main": "index.js",
   "scripts": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -42,7 +42,13 @@ describe('index test', () => {
 
     it('should catch an error for getUploadCoverageCmd', () => {
         const config = {
-            build: {}
+            build: {},
+            job: {
+                id: 456,
+                name: 'main',
+                permutations: [{ 'screwdriver.cd/sonarScope': 'pipeline' }]
+            },
+            pipeline: { id: 123, name: 'd2lam/mytest' }
         };
 
         instance.getUploadCoverageCmd(config)


### PR DESCRIPTION
## Context

Would be nice if users can specify job or pipeline scope for Sonar projects.

## Objective

This PR modifies method headers and passes in more data to getUploadCoverageCommand.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2152

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
