### PR TITLE
fix(2152): Pass scope instead of annotation [1]

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ This is an interface for uploading code coverage results from a Screwdriver buil
 | Parameter        | Type  |  Description |
 | :--------------- | :---- | :----------- |
 | config           | Object |             |
-| config.annotations | Object | Job annotations |
 | config.buildCredentials | Object | Information stored in the build JWT token |
+| config.projectKey | String | Project key (can be directly passed in with just startTime and endTime) |
+| config.scope | String | Coverage scope (pipeline or job) |
+| config.username | String | Project username |
 
 ##### Expected Outcome
 The `getAccessToken` function should resolve a Promise with an access token that build can use to talk to the code coverage server.
@@ -28,7 +30,6 @@ The `getAccessToken` function should resolve a Promise with an access token that
 | Parameter        | Type   |  Description |
 | :--------------- | :----- | :----------- |
 | config           | Object |              |
-| config.annotations | Object | Job annotations |
 | config.jobId     | String | The unique ID for a job |
 | config.jobName   | String | The Screwdriver job name |
 | config.pipelineId | String | The unique ID for a pipeline |
@@ -36,7 +37,9 @@ The `getAccessToken` function should resolve a Promise with an access token that
 | config.prNum     | String | The pull request number |
 | config.startTime | String | The job start time |
 | config.endTime   | String | The job end time |
-| config.coverageProjectKey | String | Project key (can be directly passed in with just startTime and endTime) |
+| config.projectKey | String | Project key (can be directly passed in with just startTime and endTime) |
+| config.prParentJobId | String | PR parent job ID |
+| config.scope | String | Coverage scope (pipeline or job) |
 
 ##### Expected Outcome
 The `getInfo` function should resolve a Promise with an object with metadata about the project coverage.

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const COVERAGE_SCOPE_ANNOTATION = 'screwdriver.cd/coverageScope';
-
 /* eslint-disable no-underscore-dangle */
 class CoverageBase {
     /** Constructor for Coverage plugin

--- a/index.js
+++ b/index.js
@@ -62,8 +62,7 @@ class CoverageBase {
      * @return  {Promise}  Shell commands to upload coverage
      */
     getUploadCoverageCmd(config) {
-        const { build, job, pipeline } = config;
-        let scope = null;
+        const { build } = config;
 
         if (this.isCoverageEnabled(this.config, build) === 'false') {
             const skipMessage = 'Coverage feature is skipped. ' +
@@ -73,17 +72,7 @@ class CoverageBase {
             return Promise.resolve(`echo ${skipMessage}`);
         }
 
-        if (job && job.permutations && job.permutations[0]) {
-            scope = job.permutations[0].annotations[COVERAGE_SCOPE_ANNOTATION];
-        }
-
-        return this._getUploadCoverageCmd({
-            scope,
-            jobId: job.id,
-            pipelineId: pipeline.id,
-            jobName: job.name,
-            pipelineName: pipeline.name
-        });
+        return this._getUploadCoverageCmd();
     }
 
     _getUploadCoverageCmd() {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const COVERAGE_SCOPE_ANNOTATION = 'screwdriver.cd/coverageScope';
+
 /* eslint-disable no-underscore-dangle */
 class CoverageBase {
     /** Constructor for Coverage plugin
@@ -61,7 +63,7 @@ class CoverageBase {
      */
     getUploadCoverageCmd(config) {
         const { build, job, pipeline } = config;
-        let annotations = {};
+        let scope = null;
 
         if (this.isCoverageEnabled(this.config, build) === 'false') {
             const skipMessage = 'Coverage feature is skipped. ' +
@@ -72,11 +74,11 @@ class CoverageBase {
         }
 
         if (job && job.permutations && job.permutations[0]) {
-            annotations = job.permutations[0].annotations;
+            scope = job.permutations[0].annotations[COVERAGE_SCOPE_ANNOTATION];
         }
 
         return this._getUploadCoverageCmd({
-            annotations,
+            scope,
             jobId: job.id,
             pipelineId: pipeline.id,
             jobName: job.name,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -46,7 +46,7 @@ describe('index test', () => {
             job: {
                 id: 456,
                 name: 'main',
-                permutations: [{ 'screwdriver.cd/sonarScope': 'pipeline' }]
+                permutations: [{ annotations: { 'screwdriver.cd/sonarScope': 'pipeline' } }]
             },
             pipeline: { id: 123, name: 'd2lam/mytest' }
         };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -42,13 +42,7 @@ describe('index test', () => {
 
     it('should catch an error for getUploadCoverageCmd', () => {
         const config = {
-            build: {},
-            job: {
-                id: 456,
-                name: 'main',
-                permutations: [{ annotations: { 'screwdriver.cd/sonarScope': 'pipeline' } }]
-            },
-            pipeline: { id: 123, name: 'd2lam/mytest' }
+            build: {}
         };
 
         instance.getUploadCoverageCmd(config)


### PR DESCRIPTION
## Context
It would be nice if the launcher and UI handles logic for getting all the data coverage-sonar needs.

## Objective

This PR will pass scope string instead of annotation.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2152

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
